### PR TITLE
remove redundant npm installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-dist: trusty
-sudo: required
-group: beta
 language: node_js
 node_js:
 - "8"
@@ -28,9 +25,7 @@ before_install:
     - npm install -g ganache-cli release-it greenkeeper-lockfile
 
 install:
-- npm install -g npm
-- npm install
-- npm install -g ganache-cli release-it
+    - npm install
 
 before_script:
 - greenkeeper-lockfile-update


### PR DESCRIPTION
Not sure if there was a reason for adding this twice for Travis so I just do a PR to find it out. Also removed redundant `dist`, `sudo` entries