### PR TITLE
Touch a file when contracts are ready

### DIFF
--- a/scripts/keeper.sh
+++ b/scripts/keeper.sh
@@ -6,4 +6,7 @@ sleep 2
 
 truffle migrate
 
+# Flag to indicate contracts are ready
+touch /keeper-contracts/artifacts/ready
+
 tail -f /dev/null


### PR DESCRIPTION
## Description

Touch a file when the contracts is ready (so any dependency can check if that file exists)

## Is this PR related with an open issue?

Related to Issue oceanprotocol/docker-images#23

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [x] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()