### PR TITLE
Feature/optional wait contracts

### DIFF
--- a/scripts/keeper.sh
+++ b/scripts/keeper.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-rm -f /keeper-contracts/artifacts/ready
+[ "${LOCAL_CONTRACTS}" = "true" ] && rm -f /keeper-contracts/artifacts/ready
 ganache-cli -b ${BLOCK_TIME} --hostname "${LISTEN_ADDRESS}" --port "${LISTEN_PORT}" &
 
 sleep 2
@@ -8,6 +8,6 @@ sleep 2
 truffle migrate
 
 # Flag to indicate contracts are ready
-touch /keeper-contracts/artifacts/ready
+[ "${LOCAL_CONTRACTS}" = "true" ] && touch /keeper-contracts/artifacts/ready
 
 tail -f /dev/null


### PR DESCRIPTION
## Description

Included the variable `$LOCAL_CONTRACTS`. If it is equal to "true", it will wait for the file `/usr/local/keeper-contracts/ready` to exists before starting. In other case it will start directly.

## Is this PR related with an open issue?

Related to Issue oceanprotocol/docker-images#25

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()