### PR TITLE
Feature/did block index

### DIFF
--- a/contracts/didregistry/DIDRegistry.sol
+++ b/contracts/didregistry/DIDRegistry.sol
@@ -3,34 +3,38 @@ pragma solidity 0.4.25;
 import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
 
 contract DIDRegistry is Ownable {
-    enum DocumentType { Asset, Provider }
+    enum ValueType { 
+        DID,                // DID string e.g. 'did:op:xxx'
+        DIDRef,             // hash of DID same as in parameter (bytes32 _did) in text 0x0123abc.. or 0123abc..
+        URL,                // URL string e.g. 'http(s)://xx'
+        DDO                 // DDO string in JSON e.g. '{ "id": "did:op:xxx"...
+    }
 
-    struct Identity {
+    struct DIDRegister {
         address owner;
-        DocumentType _type;
-        uint blockNumber;
+        uint updateAt;
     }
 
     event DIDAttributeRegistered(
         bytes32 indexed did,
         address indexed owner,
-        DocumentType _type,
+        ValueType _type,
         bytes32 indexed key,
         string value,
         uint updatedAt
     );
 
-    mapping(bytes32 => Identity) public identities;
+    mapping(bytes32 => Identity) public didRegister;
 
     constructor() Ownable() public {
     }
 
-    function registerAttribute(bytes32 _did, DocumentType _type, bytes32 _key, string _value) public {
+    function registerAttribute(bytes32 _did, ValueType _type, bytes32 _key, string _value) public {
         address currentOwner;
-        currentOwner = identities[_did].owner;
+        currentOwner = didRegister[_did].owner;
         require(currentOwner == address(0x0) || currentOwner == msg.sender, 'Attributes must be registered by the DID owners.');
 
-        identities[_did] = Identity(msg.sender, _type, block.number);
+        didRegister[_did] = DIDRegister(msg.sender, block.number);
         emit DIDAttributeRegistered(_did, msg.sender, _type, _key, _value, block.number);
     }
 }

--- a/contracts/didregistry/DIDRegistry.sol
+++ b/contracts/didregistry/DIDRegistry.sol
@@ -3,7 +3,7 @@ pragma solidity 0.4.25;
 import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
 
 contract DIDRegistry is Ownable {
-    enum ValueType { 
+    enum ValueType {
         DID,                // DID string e.g. 'did:op:xxx'
         DIDRef,             // hash of DID same as in parameter (bytes32 _did) in text 0x0123abc.. or 0123abc..
         URL,                // URL string e.g. 'http(s)://xx'
@@ -24,7 +24,7 @@ contract DIDRegistry is Ownable {
         uint updatedAt
     );
 
-    mapping(bytes32 => Identity) public didRegister;
+    mapping(bytes32 => DIDRegister) public didRegister;
 
     constructor() Ownable() public {
     }
@@ -37,4 +37,13 @@ contract DIDRegistry is Ownable {
         didRegister[_did] = DIDRegister(msg.sender, block.number);
         emit DIDAttributeRegistered(_did, msg.sender, _type, _key, _value, block.number);
     }
+
+    function getUpdateAt(bytes32 _did) public view returns(uint) {
+        return didRegister[_did].updateAt;
+    }
+
+    function getOwner(bytes32 _did) public view returns(address) {
+        return didRegister[_did].owner;
+    }
+
 }

--- a/contracts/didregistry/DIDRegistry.sol
+++ b/contracts/didregistry/DIDRegistry.sol
@@ -8,6 +8,7 @@ contract DIDRegistry is Ownable {
     struct Identity {
         address owner;
         DocumentType _type;
+        uint blockNumber;
     }
 
     event DIDAttributeRegistered(
@@ -19,7 +20,7 @@ contract DIDRegistry is Ownable {
         uint updatedAt
     );
 
-    mapping(bytes32 => Identity) private identities;
+    mapping(bytes32 => Identity) public identities;
 
     constructor() Ownable() public {
     }
@@ -29,7 +30,7 @@ contract DIDRegistry is Ownable {
         currentOwner = identities[_did].owner;
         require(currentOwner == address(0x0) || currentOwner == msg.sender, 'Attributes must be registered by the DID owners.');
 
-        identities[_did] = Identity(msg.sender, _type);
+        identities[_did] = Identity(msg.sender, _type, block.number);
         emit DIDAttributeRegistered(_did, msg.sender, _type, _key, _value, block.number);
     }
 }

--- a/migrations/11_deploy_did_registry.js
+++ b/migrations/11_deploy_did_registry.js
@@ -1,0 +1,11 @@
+/* global artifacts */
+const DIDRegistry = artifacts.require('DIDRegistry.sol')
+const { saveDefinition } = require('./helper')
+
+const dIDRegistry = async (deployer, network) => {
+    await deployer.deploy(DIDRegistry)
+
+    saveDefinition(network, DIDRegistry)
+}
+
+module.exports = dIDRegistry

--- a/test/DIDRegistry.Test.js
+++ b/test/DIDRegistry.Test.js
@@ -17,8 +17,8 @@ contract('DIDRegistry', (accounts) => {
             const did = web3.utils.fromAscii('did:ocn:test-attr')
             const providerDID = 'did:ocn:provider'
             const provider = web3.utils.fromAscii('provider')
-            const assetType = 0
-            const result = await registry.registerAttribute(did, assetType, provider, providerDID)
+            const valueType = 0
+            const result = await registry.registerAttribute(did, valueType, provider, providerDID)
 
             utils.assertEmitted(result, 1, 'DIDAttributeRegistered')
 
@@ -30,17 +30,62 @@ contract('DIDRegistry', (accounts) => {
             assert.strictEqual(providerDID, payload.value)
         })
 
+        it('Should find the event from the block number', async () => {
+            const registry = await DIDRegistry.new()
+
+            const did = web3.utils.sha3('did:ocn:test-read-event-from-filter-using-block-number')
+            const providerDID = 'did:ocn:provider'
+            const providerKey = web3.utils.fromAscii('provider')
+            const valueType = 0
+            const result = await registry.registerAttribute(did, valueType, providerKey, providerDID)
+
+            utils.assertEmitted(result, 1, 'DIDAttributeRegistered')
+
+            // get struct data
+            const data = await registry.didRegister(did)
+
+            // get owner for a did
+            const owner = await registry.getOwner(did)
+            assert.strictEqual(data[0], owner)
+
+            // get the blockNumber for the last update
+            const blockNumber = await registry.getUpdateAt(did)
+            assert.deepEqual(data[1], blockNumber)
+
+            // filter on the blockNumber only
+            const filterOptions = {
+                fromBlock: blockNumber,
+                toBlock: blockNumber,
+                filter: {
+                    did: did,
+                    owner: owner
+                }
+            }
+            registry.getPastEvents(filterOptions, function(error, logItems) {
+                if (!error) {
+                    if (logItems.length > 0) {
+                        const logItem = logItems[logItems.length - 1]
+                        assert.strictEqual(did, logItem.returnValues.did)
+                        assert.strictEqual(owner, logItem.returnValues.owner)
+                        assert.strictEqual(0, web3.utils.toDecimal(logItem.returnValues._type))
+                        assert.strictEqual('provider', web3.utils.hexToString(logItem.returnValues.key))
+                        assert.strictEqual(providerDID, logItem.returnValues.value)
+                    }
+                }
+            })
+        })
+
         it('Should not fail to register the same attribute twice', async () => {
             const registry = await DIDRegistry.new()
 
             const did = web3.utils.fromAscii('did:ocn:test-attr-twice')
             const providerDID = 'did:ocn:provider'
             const provider = web3.utils.fromAscii('provider')
-            const assetType = 0
+            const valueType = 0
 
-            await registry.registerAttribute(did, assetType, provider, providerDID)
+            await registry.registerAttribute(did, valueType, provider, providerDID)
             // try to register the same attribute the second time
-            const result = await registry.registerAttribute(did, assetType, provider, providerDID)
+            const result = await registry.registerAttribute(did, valueType, provider, providerDID)
 
             utils.assertEmitted(result, 1, 'DIDAttributeRegistered')
         })
@@ -52,9 +97,9 @@ contract('DIDRegistry', (accounts) => {
             const did = web3.utils.sha3(crazyLongDID)
             const providerDID = 'did:ocn:provider'
             const provider = web3.utils.fromAscii('provider')
-            const assetType = 0
+            const valueType = 0
 
-            const result = await registry.registerAttribute(did, assetType, provider, providerDID)
+            const result = await registry.registerAttribute(did, valueType, provider, providerDID)
             const payload = result.logs[0].args
             assert.strictEqual(did, payload.did)
         })
@@ -65,13 +110,13 @@ contract('DIDRegistry', (accounts) => {
             const did = web3.utils.fromAscii('did:ocn:test-multiple-attrs')
             const providerDID = 'http://example.com'
             const provider = web3.utils.fromAscii('provider')
-            const assetType = 0
+            const valueType = 0
 
-            await registry.registerAttribute(did, assetType, provider, providerDID)
+            await registry.registerAttribute(did, valueType, provider, providerDID)
 
             const nameKey = web3.utils.fromAscii('name')
             const name = 'My asset.'
-            const result = await registry.registerAttribute(did, assetType, nameKey, name)
+            const result = await registry.registerAttribute(did, valueType, nameKey, name)
 
             utils.assertEmitted(result, 1, 'DIDAttributeRegistered')
 
@@ -89,19 +134,19 @@ contract('DIDRegistry', (accounts) => {
             const did = web3.utils.fromAscii('did:ocn:test-ownership')
             const providerDID = 'did:ocn:provider'
             const provider = web3.utils.fromAscii('provider')
-            const assetType = 0
+            const valueType = 0
 
-            await registry.registerAttribute(did, assetType, provider, providerDID)
+            await registry.registerAttribute(did, valueType, provider, providerDID)
 
             const anotherPerson = { from: accounts[1] }
             const anotherDID = web3.utils.fromAscii('did:ocn:test-another-owner')
             // a different owner can register his own DID
-            await registry.registerAttribute(anotherDID, assetType, provider, providerDID, anotherPerson)
+            await registry.registerAttribute(anotherDID, valueType, provider, providerDID, anotherPerson)
 
             var failed = false
             try {
                 // must not be able to add attributes to someone else's DID
-                await registry.registerAttribute(did, assetType, provider, providerDID, anotherPerson)
+                await registry.registerAttribute(did, valueType, provider, providerDID, anotherPerson)
             } catch (e) {
                 failed = true
             }


### PR DESCRIPTION
## Description

As part of the process of getting the *Universal DID Resolver* working.

I want to get the latest DID event log from the block chain without doing the following:
1. Search the whole block chain for an event.

1. Behind the *Squid* library, having to a run a background process that is always listening for events, and then updating a local cache database for detected events.

So I have done the following:

1. Added a ```uint blockNumber``` to the DIDRegistry global data structure.

1. Renamed the ```FileType``` to ```ValueType``` so that when we pass different values in the ```String Value``` field, they can be identified. In theory we do not need this field, as the value field can be determined by looking at the contents, and doing a regex.

1. Renamed the ```identities``` structure and made it Public. So this can be accessed directly via web3 py/js. I assume for security that this only provides **getter functionality**.

1. Add in 2 new properties to read the global structure base on the registered DID.

1. Test to prove that we can access past data from the logs, using the returned block number.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [ ] Documentation
