### PR TITLE
Use bumpversion manually to bump all the versions

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,4 +4,5 @@ current_version = 0.3.3
 [bumpversion:file:setup.cfg]
 [bumpversion:file:setup.py]
 [bumpversion:file:package.json]
+[bumpversion:file:package-lock.json]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ matrix:
     - git status
     - git add package-lock.json
     - git diff-index --quiet HEAD || git commit -m "Travis update"
-    - npm run release
     after_script:
     - greenkeeper-lockfile-upload
   - language: node_js
@@ -53,7 +52,6 @@ matrix:
     - git status
     - git add package-lock.json
     - git diff-index --quiet HEAD || git commit -m "Travis update"
-    - npm run release
     after_script:
     - greenkeeper-lockfile-upload
   - language: node_js
@@ -80,7 +78,6 @@ matrix:
     - git status
     - git add package-lock.json
     - git diff-index --quiet HEAD || git commit -m "Travis update"
-    - npm run release
     after_script:
     - greenkeeper-lockfile-upload
   - language: python

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ await auth.verifyAccessTokenDelivery(accessId, accounts[1], fixedMsgSha, sig.v, 
 
 ## New Version
 
-The `bumpversion.sh` script helps to bump the project version. You can execute the script using as first argument {major|minor|patch} to bump accordingly the version.
+The `bumpversion.sh` script helps to bump the project version. You can execute the script using as first argument {major|minor|patch} to bump accordingly the version. Also you can provide the option `--tag` to automatically create the version tag.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "migrate:mainnet": "npm run migrate ----network mainnet",
     "test": "truffle test",
     "test:cover": "solidity-coverage",
-    "release": "release-it patch -n",
+    "release": "./bumpversion.sh patch",
     "clean": "rm -rf ./build/ && rm -rf ./artifacts/*.development.json",
     "lint": "npm run lint:eslint && npm run lint:solium",
     "lint:eslint": "eslint --ignore-pattern '/coverage/' .",


### PR DESCRIPTION
## Description

Remove travis line to automatically run `release-it`to bump the patch version before deployment. Now versions must be bumped manually using `bumpversion.sh` script before creating and pushing a tag to github.
 
## Is this PR related with an open issue?

Related to Issue #149 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [x] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()