### PR TITLE
fix templateId

### DIFF
--- a/contracts/SLA/ServiceAgreement.sol
+++ b/contracts/SLA/ServiceAgreement.sol
@@ -39,6 +39,8 @@ contract ServiceAgreement {
     // map template Id to a list of agreement instances
     mapping(bytes32 => bytes32[]) templateId2Agreements;
 
+    uint256 private templateIndexId = 0;
+
     // is able to revoke agreement template (template is no longer accessible)
     modifier canRevokeTemplate(bytes32 templateId){
         for (uint256 i = 0; i < templateId2Agreements[templateId].length; i++) {
@@ -97,8 +99,10 @@ contract ServiceAgreement {
         // TODO: whitelisting the contracts/fingerprints
         require(contracts.length == fingerprints.length, 'fingerprints and contracts length do not match');
         require(contracts.length == dependenciesBits.length, 'contracts and dependencies do not match');
-        // 1. generate service ID
-        bytes32 templateId = keccak256(abi.encodePacked(msg.sender, service, dependenciesBits.length, contracts.length));
+        // 1. generate service ID [for trilobite use incremental Id). This not secure and it might lead to race-condition issue and
+        // should be something like this: bytes32 templateId = keccak256(abi.encodePacked(msg.sender, service, dependenciesBits.length, contracts.length));
+        bytes32 templateId = keccak256(abi.encodePacked(templateIndexId));
+        templateIndexId +=1;
         // 2. generate conditions
         templates[templateId] = ServiceAgreementTemplate(true, msg.sender, new bytes32[](0), dependenciesBits);
         for (uint256 i = 0; i < contracts.length; i++) {

--- a/test/ServiceAgreement.Test.js
+++ b/test/ServiceAgreement.Test.js
@@ -99,7 +99,7 @@ contract('SLA', (accounts) => {
                 serviceTemplateId,
                 { from: SLATemplateOwner })
             // msg.sender, service, dependencies.length, contracts.length
-            const testTemplateId = web3.utils.soliditySha3({ type: 'address', value: SLATemplateOwner }, { type: 'bytes32', value: serviceTemplateId }, { type: 'uint', value: 4 }, { type: 'uint', value: 4 }).toString('hex')
+            const testTemplateId = web3.utils.soliditySha3({ type: 'uint256', value: 0 }).toString('hex')
 
             const templateId = result.logs[4].args.serviceTemplateId
             assert.strictEqual(templateId, testTemplateId, 'Template Id should match indicating creating of agreement template')


### PR DESCRIPTION
## Description

Keep the template Id predictable as follows:

- `hash(0):044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d`templateId for Download/Access use case
- `hash(1):c89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6` templateId for Fitchain use case
- `hash(2):ad7c5bef027816a800da1736444fb58a807ef4c9603b7848673f7e3a68eb14a5`templateId for Azure/Compute use case

**Please do note that THIS IS FOR TRILOBITE and might lead to security issues such as race-condition.**

## Is this PR related with an open issue?

Related to Issue [#186](https://github.com/oceanprotocol/ocean/issues/186)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [x] Documentation

#### Funny gif

![](https://media.giphy.com/media/pWnEWt09mJ76o/giphy.gif)