### PR TITLE
Fix/get template Id from sender

### DIFF
--- a/test/SLA.Test.js
+++ b/test/SLA.Test.js
@@ -28,6 +28,7 @@ contract('ServiceAgreement', (accounts) => {
         const fulfilmentOperator = 0 // AND
         const dependencies = [0, 1, 4, 1 | 2 ** 4 | 2 ** 5] // dependency bit | timeout bit
         const did = '0x319d158c3a5d81d15b0160cf8929916089218bdb4aa78c3ecd16633afd44b8ae'
+        const serviceTemplateId = '0x419d158c3a5d81d15b0160cf8929916089218bdb4aa78c3ecd16633afd44b8ae'
         before(async () => {
             token = await OceanToken.new()
             // await token.setReceiver(consumer)
@@ -58,7 +59,7 @@ contract('ServiceAgreement', (accounts) => {
             console.log('conditions control contracts', contracts)
             console.log('functions: ', funcFingerPrints, valuesHashList)
             const setupTx = await sla.setupAgreementTemplate(
-                contracts, funcFingerPrints, dependencies,
+                serviceTemplateId, contracts, funcFingerPrints, dependencies,
                 web3.utils.fromAscii(serviceName), fulfillmentIndices,
                 fulfilmentOperator, fromProvider
             )

--- a/test/ServiceAgreement.Test.js
+++ b/test/ServiceAgreement.Test.js
@@ -93,6 +93,7 @@ contract('SLA', (accounts) => {
             // setup service level agreement template
             console.log('\t >> Create service level agreement template')
             const result = await sla.setupAgreementTemplate(
+                serviceTemplateId,
                 contracts,
                 fingerprints,
                 dependencies,
@@ -101,10 +102,9 @@ contract('SLA', (accounts) => {
                 { from: SLATemplateOwner })
 
             // msg.sender, service, dependencies.length, contracts.length
-            const testTemplateId = web3.utils.soliditySha3({ type: 'uint256', value: 0 }).toString('hex')
 
             const templateId = result.logs[4].args.serviceTemplateId
-            assert.strictEqual(templateId, testTemplateId, 'Template Id should match indicating creating of agreement template')
+            assert.strictEqual(templateId, serviceTemplateId, 'Template Id should match indicating creating of agreement template')
             console.log('\x1b[36m%s\x1b[0m', '\t >> Template ID:', templateId, '... Done!')
             console.log('\t >> Execute service level agreement')
             // reconstruct the three condition keys off-chain

--- a/test/Test.PaymentConditions.js
+++ b/test/Test.PaymentConditions.js
@@ -10,6 +10,7 @@ const utils = require('./utils.js')
 const Web3 = require('web3')
 const web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:8545'))
 const did = '0x319d158c3a5d81d15b0160cf8929916089218bdb4aa78c3ecd16633afd44b8ae'
+const serviceTemplateId = '0x419d158c3a5d81d15b0160cf8929916089218bdb4aa78c3ecd16633afd44b8ae'
 
 contract('PaymentConditions', (accounts) => {
     describe('Tests payment conditions used in SLAs', () => {
@@ -27,7 +28,6 @@ contract('PaymentConditions', (accounts) => {
         let fingerprints
         let dependencies
         let hashes
-
         const timeouts = [0, 0, 0]
 
         const walletAllowance = 1000
@@ -68,6 +68,7 @@ contract('PaymentConditions', (accounts) => {
             const fulfilmentOperator = 0 // AND
 
             const result = await agreement.setupAgreementTemplate(
+                serviceTemplateId,
                 contracts,
                 fingerprints,
                 dependencies,


### PR DESCRIPTION
## Description

The SLA contract no longer generates templateID, it receives templateID from `sender` while calling `setupAgreementTemplate`.

## Is this PR related with an open issue?

Related to Issue [#186](https://github.com/oceanprotocol/ocean/issues/186)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [x] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()