### PR TITLE
Fix/docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:10-alpine
 LABEL maintainer="Ocean Protocol <devops@oceanprotocol.com>"
 
 RUN apk add --no-cache --update\
@@ -16,7 +16,7 @@ COPY . /keeper-contracts
 WORKDIR /keeper-contracts
 
 RUN npm install -g npm
-RUN npm install -g ganache-cli
+RUN npm install -g ganache-cli@~6.1.8
 RUN npm install
 
 # Default ENV values

--- a/scripts/keeper.sh
+++ b/scripts/keeper.sh
@@ -2,6 +2,8 @@
 
 [ "${LOCAL_CONTRACTS}" = "true" ] && rm -f /keeper-contracts/artifacts/ready
 
+npm run clean
+
 if [ "${NETWORK_NAME}" = "kovan" ]
 then
     parity --chain=kovan \


### PR DESCRIPTION
## Description

Docker build fails because of ganache update: https://hub.docker.com/r/oceanprotocol/keeper-contracts/builds/bcjwwvtr8fsmpwky5tbripq/
I also added npm run clean to avoid old artifacts being deployed in docker instance.