### PR TITLE
Fitchain & compute test coverage

### DIFF
--- a/contracts/SEA/ComputeConditions.sol
+++ b/contracts/SEA/ComputeConditions.sol
@@ -102,7 +102,7 @@ contract ComputeConditions is Common {
         if (proofs[agreementId].exists) {
             require(
                 !proofs[agreementId].isLocked,
-                "avoid race conditions"
+                'avoid race conditions'
             );
             proofs[agreementId].isLocked = true;
             proofs[agreementId].algorithmHashSignature = signature;
@@ -148,7 +148,7 @@ contract ComputeConditions is Common {
         if (proofs[agreementId].exists) {
             require(
                 !proofs[agreementId].isLocked,
-                "avoid race conditions"
+                'avoid race conditions'
             );
             proofs[agreementId].isLocked = true;
             proofs[agreementId].algorithmHash = hash;
@@ -199,7 +199,7 @@ contract ComputeConditions is Common {
                 agreementId,
                 condition
             ),
-            "condition has unfulfilled dependencies"
+            'condition has unfulfilled dependencies'
         );
 
         if (

--- a/contracts/SEA/FitchainConditions.sol
+++ b/contracts/SEA/FitchainConditions.sol
@@ -251,11 +251,14 @@ contract FitchainConditions{
         onlyPublisher(modelId)
         returns(bool)
     {
-        require(k > 0, 'number of verifiers cannot smaller than 1');
-        if (registry.length < k) {
-            emit PoTInitialized(false);
-            return false;
-        }
+        require(
+            k > 0,
+            'number of verifiers cannot smaller than 1'
+        );
+        require(
+            registry.length >= k,
+            'verifiers are not available'
+        );
         // init model
         models[modelId] = Model(
             true,
@@ -298,10 +301,10 @@ contract FitchainConditions{
             k > 0,
             'number of verifiers cannot smaller than 1'
         );
-        if (registry.length < k) {
-            emit VPCInitialized(false);
-            return false;
-        }
+        require(
+            registry.length >= k,
+            'verifiers are not available'
+        );
         require(
             electRRKVerifiers(modelId, k, 2, timeout),
             'unable to allocate resources'
@@ -411,14 +414,15 @@ contract FitchainConditions{
             address(this),
             this.setPoT.selector
         );
-        if (agreementStorage.hasUnfulfilledDependencies(modelId, condition)) {
-            emit TrainingConditionState(modelId, false);
-            return false;
-        }
-        if (agreementStorage.getConditionStatus(modelId, condition) == 1) {
-            emit TrainingConditionState(modelId, true);
+        require(
+            !agreementStorage.hasUnfulfilledDependencies(
+                modelId,
+                condition
+            ),
+            "condition has unfulfilled dependencies"
+        );
+        if (agreementStorage.getConditionStatus(modelId, condition) == 1)
             return true;
-        }
         agreementStorage.fulfillCondition(
             modelId,
             this.setPoT.selector,
@@ -450,14 +454,15 @@ contract FitchainConditions{
             address(this),
             this.setVPC.selector
         );
-        if (agreementStorage.hasUnfulfilledDependencies(modelId, condition)) {
-            emit VerificationConditionState(modelId, false);
-            return false;
-        }
-        if (agreementStorage.getConditionStatus(modelId, condition) == 1) {
-            emit VerificationConditionState(modelId, true);
+        require(
+            !agreementStorage.hasUnfulfilledDependencies(
+                modelId,
+                condition
+            ),
+            "condition has unfulfilled dependencies"
+        );
+        if (agreementStorage.getConditionStatus(modelId, condition) == 1)
             return true;
-        }
         agreementStorage.fulfillCondition(
             modelId,
             this.setVPC.selector,

--- a/contracts/SEA/FitchainConditions.sol
+++ b/contracts/SEA/FitchainConditions.sol
@@ -225,7 +225,10 @@ contract FitchainConditions{
         external onlyFreeSlots()
         returns(bool)
     {
-        require(removeVerifierFromRegistry(msg.sender), "invalid deregister request");
+        require(
+            removeVerifierFromRegistry(msg.sender),
+            'invalid deregister request'
+        );
         verifiers[msg.sender].isStaking = false;
         //TODO: send back stake to verifier
         verifiers[msg.sender].amount = 0;
@@ -418,7 +421,7 @@ contract FitchainConditions{
                 modelId,
                 condition
             ),
-            "condition has unfulfilled dependencies"
+            'condition has unfulfilled dependencies'
         );
         if (agreementStorage.getConditionStatus(modelId, condition) == 1)
             return true;
@@ -458,7 +461,7 @@ contract FitchainConditions{
                 modelId,
                 condition
             ),
-            "condition has unfulfilled dependencies"
+            'condition has unfulfilled dependencies'
         );
         if (agreementStorage.getConditionStatus(modelId, condition) == 1)
             return true;
@@ -550,7 +553,9 @@ contract FitchainConditions{
         }
         for(uint256 j = 0; j < registry.length; j++) {
             if (verifiers[registry[i]].slots == 0) {
-                assert(removeVerifierFromRegistry(registry[i]));
+                if (!removeVerifierFromRegistry(registry[i])){
+                    return false;
+                }
             }
         }
         return true;

--- a/contracts/SEA/FitchainConditions.sol
+++ b/contracts/SEA/FitchainConditions.sol
@@ -90,22 +90,6 @@ contract FitchainConditions{
         uint256 indexed voteType
     );
 
-    modifier onlyProvider(bytes32 modelId) {
-        require(
-            models[modelId].exists,
-            'model does not exist!'
-        );
-        require(
-            msg.sender == models[modelId].provider,
-            'invalid data-compute provider'
-        );
-        require(
-            agreementStorage.getAgreementPublisher(modelId) == msg.sender,
-            'service provider has to be provider'
-        );
-        _;
-    }
-
     modifier onlyPublisher(bytes32 modelId) {
         require(
             agreementStorage.getAgreementPublisher(modelId) == msg.sender,

--- a/contracts/SEA/FitchainConditions.sol
+++ b/contracts/SEA/FitchainConditions.sol
@@ -225,11 +225,10 @@ contract FitchainConditions{
         external onlyFreeSlots()
         returns(bool)
     {
-        if (removeVerifierFromRegistry(msg.sender)) {
-            verifiers[msg.sender].isStaking = false;
-            //TODO: send back stake to verifier
-            verifiers[msg.sender].amount = 0;
-        }
+        require(removeVerifierFromRegistry(msg.sender), "invalid deregister request");
+        verifiers[msg.sender].isStaking = false;
+        //TODO: send back stake to verifier
+        verifiers[msg.sender].amount = 0;
         emit VerifierDeregistered(msg.sender);
         return true;
     }
@@ -551,7 +550,7 @@ contract FitchainConditions{
         }
         for(uint256 j = 0; j < registry.length; j++) {
             if (verifiers[registry[i]].slots == 0) {
-                removeVerifierFromRegistry(registry[i]);
+                assert(removeVerifierFromRegistry(registry[i]));
             }
         }
         return true;

--- a/test/int/FitchainConditions.Test.js
+++ b/test/int/FitchainConditions.Test.js
@@ -128,6 +128,14 @@ contract('FitchainConditions', (accounts) => {
             const PoTstate = await fitchainConditions.setPoT(agreementId, kVerifiers, { from: publisher })
             assert.strictEqual(true, PoTstate.logs[0].args.state, 'unable to fulfill the proof of training condition')
         })
+        it('should not fulfill verification proof of PoT condition twice', async () => {
+            try{
+                await fitchainConditions.setPoT(agreementId, kVerifiers, { from: publisher })
+            }catch (e) {
+                assert.strictEqual(e.reason, 'avoid replay attack')
+                return
+            }
+        })
         it('should a byzantine GPC verifier fails to submit vote twice', async () => {
             try {
                 await fitchainConditions.voteForPoT(agreementId, true, { from: GPCVerifiers[0] })
@@ -159,6 +167,14 @@ contract('FitchainConditions', (accounts) => {
                 await fitchainConditions.freeMySlots(agreementId, { from: VPCVerifiers[i] })
             }
         })
+        it('should not fulfill verification proof of VPC condition twice', async () => {
+            try{
+                await fitchainConditions.setVPC(agreementId, kVerifiers, { from: publisher })
+            }catch (e) {
+                assert.strictEqual(e.reason, 'avoid replay attack')
+                return
+            }
+        })
         it('should verifiers should able to deregister if their slots are free', async () => {
             const deregisterVerifier1 = await fitchainConditions.deregisterVerifier({ from: verifier1 })
             const deregisterVerifier2 = await fitchainConditions.deregisterVerifier({ from: verifier2 })
@@ -167,10 +183,29 @@ contract('FitchainConditions', (accounts) => {
             assert.strictEqual(verifier2, deregisterVerifier2.logs[0].args.verifier, 'unable to deregister')
             assert.strictEqual(verifier3, deregisterVerifier3.logs[0].args.verifier, 'unable to deregister')
         })
+        it('should verifiers not able to deregister multiple times', async () => {
+            try{
+                await fitchainConditions.deregisterVerifier({ from: verifier1 })
+            } catch (e) {
+                assert.strictEqual(e.reason, 'access denied, please free some slots')
+                return
+            }
+        })
         it('should verifier able to get his free slots count', async () => {
             for (i = 0; i < VPCVerifiers.length; i++) {
                 myFreeSlots = await fitchainConditions.getMyFreeSlots({ from: VPCVerifiers[i] })
                 assert.strictEqual(slots, myFreeSlots.toNumber(), 'invalid free slots')
+            }
+        })
+        it('should actor deregister twice', async () => {
+            const slot = 1
+            await fitchainConditions.registerVerifier(slot, { from: accounts[8] })
+            await fitchainConditions.deregisterVerifier({ from: accounts[8] })
+            try{
+                await fitchainConditions.deregisterVerifier({ from: accounts[8] })
+            } catch (e) {
+                assert.strictEqual(e.reason, 'invalid deregister request')
+                return
             }
         })
     })

--- a/test/int/FitchainConditions.Test.js
+++ b/test/int/FitchainConditions.Test.js
@@ -129,11 +129,10 @@ contract('FitchainConditions', (accounts) => {
             assert.strictEqual(true, PoTstate.logs[0].args.state, 'unable to fulfill the proof of training condition')
         })
         it('should not fulfill verification proof of PoT condition twice', async () => {
-            try{
+            try {
                 await fitchainConditions.setPoT(agreementId, kVerifiers, { from: publisher })
-            }catch (e) {
+            } catch (e) {
                 assert.strictEqual(e.reason, 'avoid replay attack')
-                return
             }
         })
         it('should a byzantine GPC verifier fails to submit vote twice', async () => {
@@ -168,11 +167,10 @@ contract('FitchainConditions', (accounts) => {
             }
         })
         it('should not fulfill verification proof of VPC condition twice', async () => {
-            try{
+            try {
                 await fitchainConditions.setVPC(agreementId, kVerifiers, { from: publisher })
-            }catch (e) {
+            } catch (e) {
                 assert.strictEqual(e.reason, 'avoid replay attack')
-                return
             }
         })
         it('should verifiers should able to deregister if their slots are free', async () => {
@@ -184,11 +182,10 @@ contract('FitchainConditions', (accounts) => {
             assert.strictEqual(verifier3, deregisterVerifier3.logs[0].args.verifier, 'unable to deregister')
         })
         it('should verifiers not able to deregister multiple times', async () => {
-            try{
+            try {
                 await fitchainConditions.deregisterVerifier({ from: verifier1 })
             } catch (e) {
                 assert.strictEqual(e.reason, 'access denied, please free some slots')
-                return
             }
         })
         it('should verifier able to get his free slots count', async () => {
@@ -201,11 +198,10 @@ contract('FitchainConditions', (accounts) => {
             const slot = 1
             await fitchainConditions.registerVerifier(slot, { from: accounts[8] })
             await fitchainConditions.deregisterVerifier({ from: accounts[8] })
-            try{
+            try {
                 await fitchainConditions.deregisterVerifier({ from: accounts[8] })
             } catch (e) {
                 assert.strictEqual(e.reason, 'invalid deregister request')
-                return
             }
         })
     })

--- a/test/unit/SEA/ComputeConditions/fulfillUpload.js
+++ b/test/unit/SEA/ComputeConditions/fulfillUpload.js
@@ -101,10 +101,14 @@ contract('ComputeConditions', (accounts) => {
             await computeConditions.submitHashSignature(agreementId, utils.emptyBytes32, { from: consumer })
 
             // act
-            const result = await computeConditions.fulfillUpload(agreementId, utils.emptyBytes32, { from: accounts[0] })
-
-            // assert
-            utils.assertEmitted(result, 1, 'ProofOfUploadInvalid')
+            try{
+                await computeConditions.fulfillUpload(agreementId, utils.emptyBytes32, { from: accounts[0] })
+            }
+            catch (e) {
+                assert.strictEqual(e.reason, 'condition has unfulfilled dependencies')
+                return
+            }
+            assert.fail('Expected revert not received')
         })
 
         it('Should fulfill upload when hash is valid', async () => {

--- a/test/unit/SEA/ComputeConditions/fulfillUpload.js
+++ b/test/unit/SEA/ComputeConditions/fulfillUpload.js
@@ -101,10 +101,9 @@ contract('ComputeConditions', (accounts) => {
             await computeConditions.submitHashSignature(agreementId, utils.emptyBytes32, { from: consumer })
 
             // act
-            try{
+            try {
                 await computeConditions.fulfillUpload(agreementId, utils.emptyBytes32, { from: accounts[0] })
-            }
-            catch (e) {
+            } catch (e) {
                 assert.strictEqual(e.reason, 'condition has unfulfilled dependencies')
                 return
             }


### PR DESCRIPTION
## Description

Missing unit tests for compute and fitchain conditions. 

- There are two lines in the `fitchain conditions` where the function is private and in order to test them, you have to have a race condition.
- ServiceAgreement.sol will be covered in a different PR.

## Is this PR related with an open issue?

Related to Issue [#205](https://github.com/oceanprotocol/keeper-contracts/issues/205)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [x] Tests Cover Changes
- [x] Documentation

![image](https://user-images.githubusercontent.com/5428661/50979078-0af74b80-14f6-11e9-9467-01a215e44e44.png)
