### PR TITLE
Changing artifacts UID and GID

### DIFF
--- a/scripts/keeper.sh
+++ b/scripts/keeper.sh
@@ -16,4 +16,11 @@ then
     touch /keeper-contracts/artifacts/ready
 fi
 
+# Fix file permissions
+EXECUTION_UID=$(id -u)
+EXECUTION_GID=$(id -g)
+USER_ID=${LOCAL_USER_ID:-$EXECUTION_UID}
+GROUP_ID=${LOCAL_GROUP_ID:-$EXECUTION_GID}
+chown -R $USER_ID:$GROUP_ID /keeper-contracts/artifacts
+
 tail -f /dev/null


### PR DESCRIPTION
## Description

Change the artifacts owner after creation to avoid root owner on the host when running keeper-contracts inside a container.

## Is this PR related with an open issue?

Related to Issue oceanprotocol/barge#100 and oceanprotocol/barge#98

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()