### PR TITLE
convenience: indexed storage did + stake example (bonus)

### DIFF
--- a/contracts/agreements/AgreementStoreLibrary.sol
+++ b/contracts/agreements/AgreementStoreLibrary.sol
@@ -14,6 +14,7 @@ library AgreementStoreLibrary {
     struct AgreementList {
         mapping(bytes32 => Agreement) agreements;
         mapping(bytes32 => bytes32[]) didToAgreementIds;
+        mapping(address => bytes32[]) templateIdToAgreementIds;
         bytes32[] agreementIds;
     }
 
@@ -40,6 +41,7 @@ library AgreementStoreLibrary {
         });
         _self.agreementIds.push(_id);
         _self.didToAgreementIds[_did].push(_id);
+        _self.templateIdToAgreementIds[_templateId].push(_id);
         return _self.agreementIds.length;
     }
 }

--- a/contracts/agreements/AgreementStoreLibrary.sol
+++ b/contracts/agreements/AgreementStoreLibrary.sol
@@ -4,7 +4,6 @@ pragma solidity 0.5.3;
 library AgreementStoreLibrary {
 
     struct Agreement {
-        bytes32 did;
         address templateId;
         bytes32[] conditionIds;
         address lastUpdatedBy;
@@ -13,6 +12,8 @@ library AgreementStoreLibrary {
 
     struct AgreementList {
         mapping(bytes32 => Agreement) agreements;
+        mapping(bytes32 => bytes32) agreementIdToDID;
+        mapping(bytes32 => bytes32[]) didToAgreementIds;
         bytes32[] agreementIds;
     }
 
@@ -31,13 +32,14 @@ library AgreementStoreLibrary {
             'Id already exists'
         );
         _self.agreements[_id] = Agreement({
-            did: _did,
             templateId: _templateId,
             conditionIds: _conditionIds,
             lastUpdatedBy: msg.sender,
             blockNumberUpdated: block.number
         });
         _self.agreementIds.push(_id);
+        _self.agreementIdToDID[_id] = _did;
+        _self.didToAgreementIds[_did].push(_id);
         return _self.agreementIds.length;
     }
 }

--- a/contracts/agreements/AgreementStoreLibrary.sol
+++ b/contracts/agreements/AgreementStoreLibrary.sol
@@ -4,6 +4,7 @@ pragma solidity 0.5.3;
 library AgreementStoreLibrary {
 
     struct Agreement {
+        bytes32 did;
         address templateId;
         bytes32[] conditionIds;
         address lastUpdatedBy;
@@ -12,7 +13,6 @@ library AgreementStoreLibrary {
 
     struct AgreementList {
         mapping(bytes32 => Agreement) agreements;
-        mapping(bytes32 => bytes32) agreementIdToDID;
         mapping(bytes32 => bytes32[]) didToAgreementIds;
         bytes32[] agreementIds;
     }
@@ -32,13 +32,13 @@ library AgreementStoreLibrary {
             'Id already exists'
         );
         _self.agreements[_id] = Agreement({
+            did: _did,
             templateId: _templateId,
             conditionIds: _conditionIds,
             lastUpdatedBy: msg.sender,
             blockNumberUpdated: block.number
         });
         _self.agreementIds.push(_id);
-        _self.agreementIdToDID[_id] = _did;
         _self.didToAgreementIds[_did].push(_id);
         return _self.agreementIds.length;
     }

--- a/contracts/agreements/AgreementStoreManager.sol
+++ b/contracts/agreements/AgreementStoreManager.sol
@@ -160,7 +160,7 @@ contract AgreementStoreManager is Ownable {
             uint256 blockNumberUpdated
         )
     {
-        did = agreementList.agreementIdToDID[_id];
+        did = agreementList.agreements[_id].did;
         didOwner = didRegistry.getDIDOwner(did);
         templateId = agreementList.agreements[_id].templateId;
         conditionIds = agreementList.agreements[_id].conditionIds;
@@ -178,7 +178,7 @@ contract AgreementStoreManager is Ownable {
         view
         returns (address didOwner)
     {
-        bytes32 did = agreementList.agreementIdToDID[_id];
+        bytes32 did = agreementList.agreements[_id].did;
         return didRegistry.getDIDOwner(did);
     }
 

--- a/contracts/agreements/AgreementStoreManager.sol
+++ b/contracts/agreements/AgreementStoreManager.sol
@@ -160,7 +160,7 @@ contract AgreementStoreManager is Ownable {
             uint256 blockNumberUpdated
         )
     {
-        did = agreementList.agreements[_id].did;
+        did = agreementList.agreementIdToDID[_id];
         didOwner = didRegistry.getDIDOwner(did);
         templateId = agreementList.agreements[_id].templateId;
         conditionIds = agreementList.agreements[_id].conditionIds;
@@ -178,7 +178,7 @@ contract AgreementStoreManager is Ownable {
         view
         returns (address didOwner)
     {
-        bytes32 did = agreementList.agreements[_id].did;
+        bytes32 did = agreementList.agreementIdToDID[_id];
         return didRegistry.getDIDOwner(did);
     }
 
@@ -191,5 +191,17 @@ contract AgreementStoreManager is Ownable {
         returns (uint size)
     {
         return agreementList.agreementIds.length;
+    }
+
+    /**
+     * @param _did is the bytes32 DID of the asset.
+     * @return the agreement IDs for a given DID
+     */
+    function getAgreementIdsForDID(bytes32 _did)
+        public
+        view
+        returns (bytes32[] memory)
+    {
+        return agreementList.didToAgreementIds[_did];
     }
 }

--- a/contracts/agreements/AgreementStoreManager.sol
+++ b/contracts/agreements/AgreementStoreManager.sol
@@ -115,7 +115,7 @@ contract AgreementStoreManager is Ownable {
             'Arguments have wrong length'
         );
 
-        // create the conditions in condition store. Can fail if conditionID already exists.
+        // create the conditions in condition store. Fail if conditionId already exists.
         for (uint256 i = 0; i < _conditionTypes.length; i++) {
             conditionStoreManager.createCondition(
                 _conditionIds[i],
@@ -203,5 +203,17 @@ contract AgreementStoreManager is Ownable {
         returns (bytes32[] memory)
     {
         return agreementList.didToAgreementIds[_did];
+    }
+
+    /**
+     * @param _templateId is the address of the agreement template.
+     * @return the agreement IDs for a given DID
+     */
+    function getAgreementIdsForTemplateId(address _templateId)
+        public
+        view
+        returns (bytes32[] memory)
+    {
+        return agreementList.templateIdToAgreementIds[_templateId];
     }
 }

--- a/test/helpers/increaseTime.js
+++ b/test/helpers/increaseTime.js
@@ -1,6 +1,7 @@
 const testUtils = require('./utils')
 const web3 = testUtils.getWeb3()
 
+// https://stackoverflow.com/a/30452949
 const times = x => f => {
     if (x > 0) {
         f()

--- a/test/helpers/increaseTime.js
+++ b/test/helpers/increaseTime.js
@@ -1,16 +1,22 @@
 const testUtils = require('./utils')
 const web3 = testUtils.getWeb3()
 
-// source: https://michalzalecki.com/ethereum-test-driven-introduction-to-solidity-part-2/
-const increaseTime = function increaseTime(duration) {
-    const id = Date.now()
+const times = x => f => {
+    if (x > 0) {
+        f()
+        times(x - 1)(f)
+    }
+}
 
+// source: https://michalzalecki.com/ethereum-test-driven-introduction-to-solidity-part-2/
+const increaseTimeOnce = function() {
+    const id = Date.now()
     return new Promise((resolve, reject) => {
         web3.currentProvider.send(
             {
                 jsonrpc: '2.0',
                 method: 'evm_increaseTime',
-                params: [duration],
+                params: [1],
                 id: id
             },
             err1 => {
@@ -29,6 +35,10 @@ const increaseTime = function increaseTime(duration) {
             }
         )
     })
+}
+
+const increaseTime = async (duration) => {
+    times(duration)(() => increaseTimeOnce())
 }
 
 module.exports = increaseTime

--- a/test/int/agreement/StakeAgreement.Test.js
+++ b/test/int/agreement/StakeAgreement.Test.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 /* eslint-disable no-console */
-/* global artifacts, contract, describe, it, expect */
+/* global artifacts, contract, describe, it */
 
 const chai = require('chai')
 const { assert } = chai

--- a/test/int/agreement/StakeAgreement.Test.js
+++ b/test/int/agreement/StakeAgreement.Test.js
@@ -1,0 +1,208 @@
+/* eslint-env mocha */
+/* eslint-disable no-console */
+/* global artifacts, contract, describe, it, expect */
+
+const chai = require('chai')
+const { assert } = chai
+const chaiAsPromised = require('chai-as-promised')
+chai.use(chaiAsPromised)
+
+const EpochLibrary = artifacts.require('EpochLibrary')
+const DIDRegistryLibrary = artifacts.require('DIDRegistryLibrary')
+const DIDRegistry = artifacts.require('DIDRegistry')
+const AgreementStoreLibrary = artifacts.require('AgreementStoreLibrary')
+const ConditionStoreManager = artifacts.require('ConditionStoreManager')
+const TemplateStoreManager = artifacts.require('TemplateStoreManager')
+const AgreementStoreManager = artifacts.require('AgreementStoreManager')
+const OceanToken = artifacts.require('OceanToken')
+const LockRewardCondition = artifacts.require('LockRewardCondition')
+const SignCondition = artifacts.require('SignCondition')
+const EscrowReward = artifacts.require('EscrowReward')
+
+const constants = require('../../helpers/constants.js')
+const getBalance = require('../../helpers/getBalance.js')
+
+contract('Escrow Access Secret Store integration test', (accounts) => {
+    async function setupTest({
+        agreementId = constants.bytes32.one,
+        conditionIds = [constants.address.dummy],
+        deployer = accounts[8],
+        owner = accounts[9]
+    } = {}) {
+        const didRegistryLibrary = await DIDRegistryLibrary.new()
+        await DIDRegistry.link('DIDRegistryLibrary', didRegistryLibrary.address)
+        const didRegistry = await DIDRegistry.new()
+        await didRegistry.initialize(owner)
+
+        const epochLibrary = await EpochLibrary.new({ from: deployer })
+        await ConditionStoreManager.link('EpochLibrary', epochLibrary.address)
+        const conditionStoreManager = await ConditionStoreManager.new({ from: deployer })
+
+        const templateStoreManager = await TemplateStoreManager.new({ from: deployer })
+        await templateStoreManager.initialize(
+            owner,
+            { from: deployer }
+        )
+
+        const agreementStoreLibrary = await AgreementStoreLibrary.new({ from: deployer })
+        await AgreementStoreManager.link('AgreementStoreLibrary', agreementStoreLibrary.address)
+        const agreementStoreManager = await AgreementStoreManager.new({ from: deployer })
+        await agreementStoreManager.methods['initialize(address,address,address,address)'](
+            owner,
+            conditionStoreManager.address,
+            templateStoreManager.address,
+            didRegistry.address,
+            { from: deployer }
+        )
+
+        await conditionStoreManager.initialize(
+            owner,
+            agreementStoreManager.address,
+            { from: deployer }
+        )
+
+        const oceanToken = await OceanToken.new({ from: deployer })
+        await oceanToken.initialize(owner, owner)
+
+        const lockRewardCondition = await LockRewardCondition.new({ from: deployer })
+        await lockRewardCondition.initialize(
+            owner,
+            conditionStoreManager.address,
+            oceanToken.address,
+            { from: deployer }
+        )
+
+        const escrowReward = await EscrowReward.new({ from: deployer })
+        await escrowReward.initialize(
+            owner,
+            conditionStoreManager.address,
+            oceanToken.address,
+            { from: deployer }
+        )
+
+        const signCondition = await SignCondition.new()
+        await signCondition.initialize(
+            owner,
+            conditionStoreManager.address,
+            { from: accounts[0] }
+        )
+
+        return {
+            oceanToken,
+            didRegistry,
+            agreementStoreManager,
+            conditionStoreManager,
+            templateStoreManager,
+            lockRewardCondition,
+            signCondition,
+            escrowReward,
+            agreementId,
+            conditionIds,
+            owner
+        }
+    }
+
+    describe('create and fulfill escrow agreement', () => {
+        it('should create escrow agreement and fulfill', async () => {
+            const {
+                oceanToken,
+                didRegistry,
+                agreementStoreManager,
+                templateStoreManager,
+                signCondition,
+                lockRewardCondition,
+                escrowReward,
+                owner
+            } = await setupTest()
+
+            // propose and approve account as agreement factory
+            const templateId = accounts[0]
+            await templateStoreManager.proposeTemplate(templateId)
+            await templateStoreManager.approveTemplate(templateId, { from: owner })
+
+            // register DID
+            const did = constants.did[0]
+            const { url } = constants.registry
+            const checksum = constants.bytes32.one
+
+            await didRegistry.registerAttribute(did, checksum, url)
+
+            // generate IDs from attributes
+            const agreementId = constants.bytes32.one
+
+            const staker = accounts[0]
+            const amount = 10
+            const stakePeriod = 5
+            let {
+                message,
+                publicKey,
+                signature
+            } = constants.condition.sign.bytes32
+
+            let hashValuesSign = await signCondition.hashValues(message, publicKey)
+            let conditionIdSign = await signCondition.generateId(agreementId, hashValuesSign)
+
+            const hashValuesLock = await lockRewardCondition.hashValues(escrowReward.address, amount)
+            const conditionIdLock = await lockRewardCondition.generateId(agreementId, hashValuesLock)
+
+            const hashValuesEscrow = await escrowReward.hashValues(
+                amount,
+                staker,
+                staker,
+                conditionIdLock,
+                conditionIdSign)
+            const conditionIdEscrow = await escrowReward.generateId(agreementId, hashValuesEscrow)
+
+            // construct agreement
+            const agreement = {
+                did: did,
+                conditionTypes: [
+                    signCondition.address,
+                    lockRewardCondition.address,
+                    escrowReward.address
+                ],
+                conditionIds: [
+                    conditionIdSign,
+                    conditionIdLock,
+                    conditionIdEscrow
+                ],
+                timeLocks: [stakePeriod, 0, 0],
+                timeOuts: [0, 0, 0]
+            }
+
+            await agreementStoreManager.createAgreement(
+                agreementId,
+                ...Object.values(agreement)
+            )
+
+            // fulfill lock reward
+            await oceanToken.mint(staker, amount, { from: owner })
+            await oceanToken.approve(lockRewardCondition.address, amount, { from: staker })
+
+            await lockRewardCondition.fulfill(agreementId, escrowReward.address, amount)
+
+            assert.strictEqual(await getBalance(oceanToken, staker), 0)
+            assert.strictEqual(await getBalance(oceanToken, escrowReward.address), amount)
+
+            // fulfill before stake period
+            await assert.isRejected(
+                signCondition.fulfill(agreementId, message, publicKey, signature),
+                constants.condition.epoch.error.isTimeLocked
+            )
+
+            await signCondition.fulfill(agreementId, message, publicKey, signature)
+
+            // get reward
+            await escrowReward.fulfill(
+                agreementId,
+                amount,
+                staker,
+                staker,
+                conditionIdLock,
+                conditionIdSign)
+
+            assert.strictEqual(await getBalance(oceanToken, staker), amount)
+            assert.strictEqual(await getBalance(oceanToken, escrowReward.address), 0)
+        })
+    })
+})

--- a/test/int/agreement/StakeAgreement.Test.js
+++ b/test/int/agreement/StakeAgreement.Test.js
@@ -22,7 +22,7 @@ const EscrowReward = artifacts.require('EscrowReward')
 const constants = require('../../helpers/constants.js')
 const getBalance = require('../../helpers/getBalance.js')
 
-contract('Escrow Access Secret Store integration test', (accounts) => {
+contract('Stake Agreement integration test', (accounts) => {
     async function setupTest({
         agreementId = constants.bytes32.one,
         conditionIds = [constants.address.dummy],
@@ -102,8 +102,8 @@ contract('Escrow Access Secret Store integration test', (accounts) => {
         }
     }
 
-    describe('create and fulfill escrow agreement', () => {
-        it('should create escrow agreement and fulfill', async () => {
+    describe('create and fulfill stake agreement', () => {
+        it('stake agreement as an escrow with self-sign release', async () => {
             const {
                 oceanToken,
                 didRegistry,

--- a/test/int/agreement/StakeAgreement.Test.js
+++ b/test/int/agreement/StakeAgreement.Test.js
@@ -21,6 +21,7 @@ const EscrowReward = artifacts.require('EscrowReward')
 
 const constants = require('../../helpers/constants.js')
 const getBalance = require('../../helpers/getBalance.js')
+const increaseTime = require('../../helpers/increaseTime.js')
 
 contract('Stake Agreement integration test', (accounts) => {
     async function setupTest({
@@ -174,6 +175,9 @@ contract('Stake Agreement integration test', (accounts) => {
                 signCondition.fulfill(agreementId, message, publicKey, signature),
                 constants.condition.epoch.error.isTimeLocked
             )
+
+            await increaseTime(1)
+            await increaseTime(1)
 
             await signCondition.fulfill(agreementId, message, publicKey, signature)
 

--- a/test/unit/agreements/AgreementStoreManager.Test.js
+++ b/test/unit/agreements/AgreementStoreManager.Test.js
@@ -449,5 +449,50 @@ contract('AgreementStoreManager', (accounts) => {
             expect(storedAgreement.blockNumberUpdated.toNumber())
                 .to.equal(blockNumber.toNumber())
         })
+
+        it('should get multiple agreements for same did', async () => {
+            const {
+                agreementStoreManager,
+                templateStoreManager,
+                did,
+                owner
+            } = await setupTest({ registerDID: true })
+
+            const templateId = accounts[2]
+            await templateStoreManager.proposeTemplate(templateId)
+            await templateStoreManager.approveTemplate(templateId, { from: owner })
+
+            const agreement = {
+                did: did,
+                conditionTypes: [accounts[3]],
+                conditionIds: [constants.bytes32.zero],
+                timeLocks: [0],
+                timeOuts: [2]
+            }
+            const agreementId = constants.bytes32.zero
+
+            await agreementStoreManager.createAgreement(
+                agreementId,
+                ...Object.values(agreement),
+                { from: templateId }
+            )
+
+            const otherAgreement = {
+                did: did,
+                conditionTypes: [accounts[3]],
+                conditionIds: [constants.bytes32.one],
+                timeLocks: [2],
+                timeOuts: [3]
+            }
+            const otherAgreementId = constants.bytes32.one
+
+            await agreementStoreManager.createAgreement(
+                otherAgreementId,
+                ...Object.values(otherAgreement),
+                { from: templateId }
+            )
+            const agreementIds = await agreementStoreManager.getAgreementIdsForDID(did)
+            assert.lengthOf(agreementIds, 2)
+        })
     })
 })

--- a/test/unit/agreements/AgreementStoreManager.Test.js
+++ b/test/unit/agreements/AgreementStoreManager.Test.js
@@ -450,7 +450,7 @@ contract('AgreementStoreManager', (accounts) => {
                 .to.equal(blockNumber.toNumber())
         })
 
-        it('should get multiple agreements for same did', async () => {
+        it('should get multiple agreements for same did & template', async () => {
             const {
                 agreementStoreManager,
                 templateStoreManager,
@@ -491,8 +491,13 @@ contract('AgreementStoreManager', (accounts) => {
                 ...Object.values(otherAgreement),
                 { from: templateId }
             )
-            const agreementIds = await agreementStoreManager.getAgreementIdsForDID(did)
-            assert.lengthOf(agreementIds, 2)
+
+            assert.lengthOf(
+                await agreementStoreManager.getAgreementIdsForDID(did),
+                2)
+            assert.lengthOf(
+                await agreementStoreManager.getAgreementIdsForTemplateId(templateId),
+                2)
         })
     })
 })


### PR DESCRIPTION
Adding some storage indexes for easy retrieval later, with associated getters:
- `getAgreementIdsForDID(did): did -> [list of agreementId]`
- `getAgreementIdsForTemplateId(templateId): templateId -> [list of agreementId]`

bonus:
example on how to create a `Stake` Agreement. 
stake is treated as an escrow:
- receiver = sender
- lock: stake
- release: sign + timelock (stakeperiod)
