### PR TITLE
Fix/v0.8 drain escrow reward

### DIFF
--- a/contracts/conditions/rewards/EscrowReward.sol
+++ b/contracts/conditions/rewards/EscrowReward.sol
@@ -74,8 +74,29 @@ contract EscrowReward is Reward {
                 _releaseCondition
             )
         );
+        address lockConditionTypeRef;
+        ConditionStoreLibrary.ConditionState lockConditionState;
+        (lockConditionTypeRef,lockConditionState,,,,,) = conditionStoreManager
+            .getCondition(_lockCondition);
+
+        bytes32 generatedLockConditionId = keccak256(
+            abi.encodePacked(
+                _agreementId,
+                lockConditionTypeRef,
+                keccak256(
+                    abi.encodePacked(
+                        address(this),
+                        _amount
+                    )
+                )
+            )
+        );
         require(
-            conditionStoreManager.getConditionState(_lockCondition) ==
+            generatedLockConditionId == _lockCondition,
+            'LockCondition ID does not match'
+        );
+        require(
+            lockConditionState ==
             ConditionStoreLibrary.ConditionState.Fulfilled,
             'LockCondition needs to be Fulfilled'
         );

--- a/test/helpers/constants.js
+++ b/test/helpers/constants.js
@@ -63,7 +63,8 @@ let constants = {
         reward: {
             escrowReward: {
                 error: {
-                    lockConditionNeedsToBeFulfilled: 'LockCondition needs to be Fulfilled'
+                    lockConditionNeedsToBeFulfilled: 'LockCondition needs to be Fulfilled',
+                    lockConditionIdDoesNotMatch: 'LockCondition ID does not match'
                 }
             }
         }

--- a/test/unit/conditions/rewards/EscrowReward.Test.js
+++ b/test/unit/conditions/rewards/EscrowReward.Test.js
@@ -195,6 +195,85 @@ contract('EscrowReward constructor', (accounts) => {
         })
     })
 
-    describe('fail to fulfill existing condition', () => {
+    describe('only fulfill conditions once', () => {
+        it('do not allow rewards to be fulfilled twice', async () => {
+            const {
+                escrowReward,
+                lockRewardCondition,
+                oceanToken,
+                conditionStoreManager,
+                owner
+            } = await setupTest()
+
+            const nonce1 = constants.bytes32.one
+            const sender = accounts[0]
+            const attacker = accounts[2]
+            const amount = 10
+
+            const hashValuesLock = await lockRewardCondition.hashValues(escrowReward.address, amount)
+            const conditionLockId = await lockRewardCondition.generateId(nonce1, hashValuesLock)
+
+            await conditionStoreManager.createCondition(
+                conditionLockId,
+                lockRewardCondition.address)
+
+            await conditionStoreManager.createCondition(
+                constants.bytes32.one,
+                escrowReward.address)
+
+            /* simulate a real environment by giving the EscrowReward contract a bunch of tokens: */
+            await oceanToken.mint(escrowReward.address, 100, {from: owner})
+
+            const lockConditionId = conditionLockId
+            const releaseConditionId = conditionLockId
+
+            /* fulfill the lock condition */
+
+            await oceanToken.mint(sender, amount, { from: owner })
+            await oceanToken.approve(
+                lockRewardCondition.address,
+                amount,
+                { from: sender })
+
+            await lockRewardCondition.fulfill(nonce1, escrowReward.address, amount)
+
+            const escrowRewardBalance = 110
+
+            /* attacker creates escrowRewardBalance/amount bogus conditions to claim the locked reward: */
+
+            for (let i=0; i<escrowRewardBalance / amount; ++i) {
+                let nonce = (3 + i).toString(16)
+                while (nonce.length < 32*2) {
+                    nonce = '0' + nonce
+                }
+                const attackNonce = '0x' + nonce
+                const attackerHashValues = await escrowReward.hashValues(
+                    amount,
+                    attacker,
+                    attacker,
+                    lockConditionId,
+                    releaseConditionId)
+                const attackerConditionId = await escrowReward.generateId(attackNonce, attackerHashValues)
+
+                await conditionStoreManager.createCondition(
+                    attackerConditionId,
+                    escrowReward.address)
+
+                /* attacker tries to claim the escrow before the legitimate users: */
+                await escrowReward.fulfill(
+                    attackNonce,
+                    amount,
+                    attacker,
+                    attacker,
+                    lockConditionId,
+                    releaseConditionId)
+            }
+
+            /* make sure the EscrowReward contract didn't get drained */
+            assert.notStrictEqual(
+                (await oceanToken.balanceOf(escrowReward.address)).toNumber(),
+                0
+            )
+        })
     })
 })

--- a/test/unit/conditions/rewards/EscrowReward.Test.js
+++ b/test/unit/conditions/rewards/EscrowReward.Test.js
@@ -103,7 +103,7 @@ contract('EscrowReward constructor', (accounts) => {
                     sender,
                     lockConditionId,
                     releaseConditionId),
-                constants.condition.reward.escrowReward.error.lockConditionNeedsToBeFulfilled
+                constants.condition.reward.escrowReward.error.lockConditionIdDoesNotMatch
             )
         })
     })
@@ -222,7 +222,7 @@ contract('EscrowReward constructor', (accounts) => {
                 escrowReward.address)
 
             /* simulate a real environment by giving the EscrowReward contract a bunch of tokens: */
-            await oceanToken.mint(escrowReward.address, 100, {from: owner})
+            await oceanToken.mint(escrowReward.address, 100, { from: owner })
 
             const lockConditionId = conditionLockId
             const releaseConditionId = conditionLockId
@@ -241,9 +241,9 @@ contract('EscrowReward constructor', (accounts) => {
 
             /* attacker creates escrowRewardBalance/amount bogus conditions to claim the locked reward: */
 
-            for (let i=0; i<escrowRewardBalance / amount; ++i) {
+            for (let i = 0; i < escrowRewardBalance / amount; ++i) {
                 let nonce = (3 + i).toString(16)
-                while (nonce.length < 32*2) {
+                while (nonce.length < 32 * 2) {
                     nonce = '0' + nonce
                 }
                 const attackNonce = '0x' + nonce
@@ -260,13 +260,16 @@ contract('EscrowReward constructor', (accounts) => {
                     escrowReward.address)
 
                 /* attacker tries to claim the escrow before the legitimate users: */
-                await escrowReward.fulfill(
-                    attackNonce,
-                    amount,
-                    attacker,
-                    attacker,
-                    lockConditionId,
-                    releaseConditionId)
+                await assert.isRejected(
+                    escrowReward.fulfill(
+                        attackNonce,
+                        amount,
+                        attacker,
+                        attacker,
+                        lockConditionId,
+                        releaseConditionId),
+                    constants.condition.reward.escrowReward.error.lockConditionIdDoesNotMatch
+                )
             }
 
             /* make sure the EscrowReward contract didn't get drained */


### PR DESCRIPTION
## Description

Escrow can be drained because the `amount` of the `lockCondition` is decoupled of the `amount` of the `reward`

Possible Solutions: 
1. keep track of the amounts for each `lockCondition` inside of the `escrowReward`
2. have an integrity check in the `escrowReward.fulfill` for the `lockCondition`