### PR TITLE
upgrade /v0.8 zos version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3084,7 +3084,7 @@
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "dev": true,
       "requires": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
         "ethereumjs-util": "^5.1.1"
       },
       "dependencies": {
@@ -4203,8 +4203,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4225,14 +4224,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4247,20 +4244,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4377,8 +4371,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4390,7 +4383,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4405,7 +4397,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4413,14 +4404,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4439,7 +4428,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4520,8 +4508,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4533,7 +4520,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4619,8 +4605,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4656,7 +4641,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4676,7 +4660,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4720,14 +4703,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -6924,12 +6905,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/openzeppelin-eth/-/openzeppelin-eth-2.1.3.tgz",
       "integrity": "sha512-k1Yv3V7u369ERXV0xf+ru3TH+ZopFYY0E1M+4O32Q+0b4XLm2acVBaUvbuuqYMkUjKhSfu8HuPpXL7OWMEJWRw==",
-      "dev": true
-    },
-    "openzeppelin-solidity": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.10.0.tgz",
-      "integrity": "sha512-igkrumQQ2lrN2zjeQV4Dnb0GpTBj1fzMcd8HPyBUqwI0hhuscX/HzXiqKT6gFQl1j9Wy/ppVVs9fqL/foF7Gmg==",
       "dev": true
     },
     "optimist": {
@@ -10443,7 +10418,7 @@
       "requires": {
         "underscore": "1.8.3",
         "web3-core-helpers": "1.0.0-beta.37",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
       },
       "dependencies": {
         "debug": {
@@ -10776,9 +10751,9 @@
       }
     },
     "zos": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/zos/-/zos-2.2.0.tgz",
-      "integrity": "sha512-45F8+DrO/IZi5pD2TX4lxzcHrgkAXQSdY4tt/D5IjFjkF2DgFrArGAFPsz/xw2+zEr0uQ+znVwfzWdn3Uwhl8g==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/zos/-/zos-2.2.1.tgz",
+      "integrity": "sha512-CSk0pi3nAzHXo3m1t6uFCAA1WSKOTb9iANZWpAMPTSFHwmkMts5GpciGIBZbElLILLLl+DeRh6AQ24CwOlVbjg==",
       "dev": true,
       "requires": {
         "@types/npm": "^2.0.29",
@@ -10822,7 +10797,7 @@
         "truffle-config": "1.1.2",
         "web3": "1.0.0-beta.37",
         "web3-provider-engine": "14.0.6",
-        "zos-lib": "^2.2.0"
+        "zos-lib": "^2.2.1"
       },
       "dependencies": {
         "async": {
@@ -10835,9 +10810,9 @@
           }
         },
         "bignumber.js": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.0.2.tgz",
-          "integrity": "sha512-EiuvFrnbv0jFixEQ9f58jo7X0qI2lNGIr/MxntmVzQc5JUweDSh8y8hbTCAomFtqwUPIOWcLXP0VEOSZTG7FFw==",
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
+          "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ==",
           "dev": true
         },
         "commander": {
@@ -10887,9 +10862,9 @@
       }
     },
     "zos-lib": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/zos-lib/-/zos-lib-2.2.0.tgz",
-      "integrity": "sha512-Hex60MlPT2AFE7G+MRxN/ip9tsVUNjOPOTvl81Qghh/ntLRvDNAxtYJaHxup3/F1xF0DuDBrYCHIRdXkR3rkXQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/zos-lib/-/zos-lib-2.2.1.tgz",
+      "integrity": "sha512-whdBpt1YneDzFzjw+uUzYVzyboDMJuNG7WOFdxkeC/+XrEbbSmPEyBU4OGc47Rt/jg+ruhbOfxsOImc+Sfnnfg==",
       "dev": true,
       "requires": {
         "@types/web3": "^1.0.14",
@@ -10918,7 +10893,6 @@
         "lodash.uniq": "^4.5.0",
         "lodash.values": "^4.3.0",
         "lodash.without": "^4.4.0",
-        "openzeppelin-solidity": "~1.10.0",
         "semver": "^5.5.1",
         "truffle-flattener": "^1.3.0",
         "web3": "1.0.0-beta.37"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "web3": "1.0.0-beta.37",
     "web3-provider-engine": "^14.1.0",
     "websocket": "^1.0.28",
-    "zos": "~2.2.0",
-    "zos-lib": "~2.2.0"
+    "zos": "~2.2.1",
+    "zos-lib": "~2.2.1"
   }
 }


### PR DESCRIPTION
https://github.com/zeppelinos/zos/releases/tag/v2.2.1
- Remove openzeppelin-solidity as a dependency