### PR TITLE
Fix/null address

### DIFF
--- a/contracts/conditions/rewards/EscrowReward.sol
+++ b/contracts/conditions/rewards/EscrowReward.sol
@@ -145,6 +145,10 @@ contract EscrowReward is Reward {
             'Null address is impossible to fulfill'
         );
         require(
+            _receiver != address(this),
+            'EscrowReward contract can not be a receiver'
+        );
+        require(
             token.transfer(_receiver, _amount),
             'Could not transfer token'
         );

--- a/contracts/conditions/rewards/EscrowReward.sol
+++ b/contracts/conditions/rewards/EscrowReward.sol
@@ -141,6 +141,10 @@ contract EscrowReward is Reward {
         returns (ConditionStoreLibrary.ConditionState)
     {
         require(
+            _receiver != address(0),
+            'Null address is impossible to fulfill'
+        );
+        require(
             token.transfer(_receiver, _amount),
             'Could not transfer token'
         );

--- a/package-lock.json
+++ b/package-lock.json
@@ -3110,7 +3110,7 @@
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "dev": true,
       "requires": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
         "ethereumjs-util": "^5.1.1"
       },
       "dependencies": {
@@ -3119,8 +3119,8 @@
           "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
           "dev": true,
           "requires": {
-            "bn.js": "^4.10.0",
-            "ethereumjs-util": "^5.0.0"
+            "bn.js": "^4.11.8",
+            "ethereumjs-util": "^6.0.0"
           }
         }
       }
@@ -4235,8 +4235,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4257,14 +4256,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4279,20 +4276,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4409,8 +4403,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4422,7 +4415,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4437,7 +4429,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4445,14 +4436,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4471,7 +4460,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4552,8 +4540,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4565,7 +4552,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4651,8 +4637,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4688,7 +4673,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4708,7 +4692,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4752,14 +4735,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -10493,7 +10474,7 @@
       "requires": {
         "underscore": "1.8.3",
         "web3-core-helpers": "1.0.0-beta.37",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
       },
       "dependencies": {
         "debug": {

--- a/test/unit/conditions/rewards/EscrowReward.Test.js
+++ b/test/unit/conditions/rewards/EscrowReward.Test.js
@@ -197,6 +197,69 @@ contract('EscrowReward constructor', (accounts) => {
                 constants.condition.state.error.invalidStateTransition
             )
         })
+        it('should not fulfill in case of null addresses', async () => {
+            const {
+                escrowReward,
+                lockRewardCondition,
+                oceanToken,
+                conditionStoreManager,
+                owner
+            } = await setupTest()
+
+            let nonce = constants.bytes32.one
+            let sender = accounts[0]
+            let receiver = constants.address.zero
+            let amount = 10
+
+            let hashValuesLock = await lockRewardCondition.hashValues(escrowReward.address, amount)
+            let conditionLockId = await lockRewardCondition.generateId(nonce, hashValuesLock)
+
+            await conditionStoreManager.createCondition(
+                conditionLockId,
+                lockRewardCondition.address)
+
+            let lockConditionId = conditionLockId
+            let releaseConditionId = conditionLockId
+
+            let hashValues = await escrowReward.hashValues(
+                amount,
+                receiver,
+                sender,
+                lockConditionId,
+                releaseConditionId)
+            let conditionId = await escrowReward.generateId(nonce, hashValues)
+
+            await conditionStoreManager.createCondition(
+                constants.bytes32.one,
+                escrowReward.address)
+
+            await conditionStoreManager.createCondition(
+                conditionId,
+                escrowReward.address)
+
+            await oceanToken.mint(sender, amount, { from: owner })
+            await oceanToken.approve(
+                lockRewardCondition.address,
+                amount,
+                { from: sender })
+
+            await lockRewardCondition.fulfill(nonce, escrowReward.address, amount)
+
+            assert.strictEqual(await getBalance(oceanToken, lockRewardCondition.address), 0)
+            assert.strictEqual(await getBalance(oceanToken, escrowReward.address), amount)
+
+            await assert.isRejected(
+                escrowReward.fulfill(
+                    nonce,
+                    amount,
+                    receiver,
+                    sender,
+                    lockConditionId,
+                    releaseConditionId
+                ),
+                'Null address is impossible to fulfill'
+            )
+        })
     })
 
     describe('only fulfill conditions once', () => {

--- a/test/unit/conditions/rewards/EscrowReward.Test.js
+++ b/test/unit/conditions/rewards/EscrowReward.Test.js
@@ -260,6 +260,69 @@ contract('EscrowReward constructor', (accounts) => {
                 'Null address is impossible to fulfill'
             )
         })
+        it('should not fulfill if the receiver address is Escrow contract address', async () => {
+            const {
+                escrowReward,
+                lockRewardCondition,
+                oceanToken,
+                conditionStoreManager,
+                owner
+            } = await setupTest()
+
+            let nonce = constants.bytes32.one
+            let sender = accounts[0]
+            let receiver = escrowReward.address
+            let amount = 10
+
+            let hashValuesLock = await lockRewardCondition.hashValues(escrowReward.address, amount)
+            let conditionLockId = await lockRewardCondition.generateId(nonce, hashValuesLock)
+
+            await conditionStoreManager.createCondition(
+                conditionLockId,
+                lockRewardCondition.address)
+
+            let lockConditionId = conditionLockId
+            let releaseConditionId = conditionLockId
+
+            let hashValues = await escrowReward.hashValues(
+                amount,
+                receiver,
+                sender,
+                lockConditionId,
+                releaseConditionId)
+            let conditionId = await escrowReward.generateId(nonce, hashValues)
+
+            await conditionStoreManager.createCondition(
+                constants.bytes32.one,
+                escrowReward.address)
+
+            await conditionStoreManager.createCondition(
+                conditionId,
+                escrowReward.address)
+
+            await oceanToken.mint(sender, amount, { from: owner })
+            await oceanToken.approve(
+                lockRewardCondition.address,
+                amount,
+                { from: sender })
+
+            await lockRewardCondition.fulfill(nonce, escrowReward.address, amount)
+
+            assert.strictEqual(await getBalance(oceanToken, lockRewardCondition.address), 0)
+            assert.strictEqual(await getBalance(oceanToken, escrowReward.address), amount)
+
+            await assert.isRejected(
+                escrowReward.fulfill(
+                    nonce,
+                    amount,
+                    receiver,
+                    sender,
+                    lockConditionId,
+                    releaseConditionId
+                ),
+                'EscrowReward contract can not be a receiver'
+            )
+        })
     })
 
     describe('only fulfill conditions once', () => {


### PR DESCRIPTION
A LockRewardCondition with null sender or receiver address is impossible to fulfill.

closes [11](https://github.com/oceanprotocol/security-issues/issues/11)