### PR TITLE
Fix/npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/oceanprotocol/keeper-contracts/issues"
   },
   "homepage": "https://github.com/oceanprotocol/keeper-contracts#readme",
-  "main": "truffle.js",
+  "main": "README.md",
   "scripts": {
     "compile": "truffle compile",
     "deploy": "npx truffle exec ./scripts/deploy/truffle-wrapper/deployContractsWrapper.js",


### PR DESCRIPTION
## Description

I always wondered why `truffle.js` was put into the `npm` package. This is why.