### PR TITLE
add audit functionality

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -161,3 +161,19 @@ It will deploy the following components:
 
 - update the new github release
   - Describe the main changes. (In the future, these will come from the changelog.)
+
+
+## Audit
+
+To check or document that all transactions have been approved in the multi sig wallet you can run `npm run audit:nile` to get a list of all the current transactions and their current status. 
+
+```text
+ Wallet: 0x24EB26D4042a2AB576E7E39b87c3f33f276AeF92
+
+ Transaction ID: 64 
+ Destination: 0xfA16d26e9F4fffC6e40963B281a0bB08C31ed40C 
+ Contract: EscrowAccessSecretStoreTemplate 
+ Data is `upgradeTo` call: true 
+ Confirmed from: 0x7A13E1aD23546c9b804aDFd13e9AcB184EfCAF58 
+ Executed: false
+```

--- a/package.json
+++ b/package.json
@@ -9,6 +9,12 @@
   "main": "README.md",
   "scripts": {
     "compile": "truffle compile",
+    "audit": "npx truffle exec ./scripts/deploy/truffle-wrapper/auditWrapper.js",
+    "audit:development": "export NETWORK=development&&npm run audit -- --network development",
+    "audit:spree": "export NETWORK=spree&&npm run audit -- --network spree",
+    "audit:duero": "export NETWORK=duero&&npm run audit -- --network duero",
+    "audit:nile": "export NETWORK=nile&&npm run audit -- --network nile",
+    "audit:kovan": "export NETWORK=kovan&&npm run audit -- --network kovan",
     "deploy": "npx truffle exec ./scripts/deploy/truffle-wrapper/deployContractsWrapper.js",
     "deploy:development": "export NETWORK=development&&npm run deploy -- --network development --testnet true",
     "deploy:spree": "export NETWORK=spree&&npm run deploy -- --network spree --testnet true",

--- a/scripts/deploy/audit/audit.js
+++ b/scripts/deploy/audit/audit.js
@@ -1,0 +1,86 @@
+const loadWallet = require('../wallet/loadWallet')
+const loadArtifacts = require('../contracts/artifacts/loadArtifacts')
+const evaluateContracts = require('../contracts/evaluateContracts')
+const createFunctionSignature = require('../contracts/artifacts/createFunctionSignature')
+
+const NETWORK = process.env.NETWORK || 'development'
+
+async function audit({
+    web3,
+    strict = false,
+    entries = 20,
+    testnet = true,
+    verbose = true
+} = {}) {
+    const upgraderWallet = await loadWallet(
+        web3,
+        'upgrader',
+        verbose
+    )
+
+    const max = entries
+    const txCount = await upgraderWallet.transactionCount()
+    const from = txCount - max > 0 ? txCount - max : 0
+    const to = txCount.toNumber()
+
+    const txIds = await upgraderWallet.getTransactionIds(
+        from,
+        to,
+        true,
+        true
+    )
+
+    const sortedTxIds = txIds.sort((a, b) => b.toNumber() - a.toNumber())
+
+    const evaluatedContracts = await evaluateContracts({
+        testnet,
+        verbose
+    })
+
+    const artifacts = await loadArtifacts({
+        contractNames: evaluatedContracts,
+        networkName: NETWORK
+    })
+
+    /* eslint-disable-next-line no-console */
+    console.log(
+        '\n',
+        'Wallet:', upgraderWallet.address
+    )
+
+    for (const txId of sortedTxIds) {
+        const transaction = await upgraderWallet.transactions(
+            txId
+        )
+
+        const sig = createFunctionSignature({
+            functionName: 'upgradeTo',
+            parameters: ['address']
+        })
+
+        const artifact = artifacts.find((a) => a.address === transaction.destination)
+        const artifactName = artifact ? artifact.name : 'Unknown'
+
+        const confirmations = await upgraderWallet.getConfirmations(
+            txId
+        )
+
+        /* eslint-disable-next-line no-console */
+        console.log(
+            '\n',
+            'Transaction ID:', txId.toString(),
+            '\n',
+            'Destination:', transaction.destination,
+            '\n',
+            'Contract:', `${artifactName}`,
+            '\n',
+            'Data is `upgradeTo` call:', transaction.data.startsWith(sig),
+            '\n',
+            'Confirmed from:', confirmations.join(', '),
+            '\n',
+            'Executed:', transaction.executed
+        )
+    }
+}
+
+module.exports = audit

--- a/scripts/deploy/contracts/artifacts/createFunctionSignature.js
+++ b/scripts/deploy/contracts/artifacts/createFunctionSignature.js
@@ -1,0 +1,13 @@
+const web3 = require('web3')
+
+function createFunctionSignature({
+    functionName,
+    parameters
+} = {}) {
+    const signature = `${functionName}(${parameters.join(',')})`
+
+    const signatureHash = web3.utils.sha3(signature)
+    return signatureHash.substring(0, 10)
+}
+
+module.exports = createFunctionSignature

--- a/scripts/deploy/contracts/artifacts/generateFunctionSignaturesInABI.js
+++ b/scripts/deploy/contracts/artifacts/generateFunctionSignaturesInABI.js
@@ -1,4 +1,4 @@
-const web3 = require('web3')
+const createFunctionSignature = require('./createFunctionSignature')
 
 function generateFunctionSignaturesInABI(
     abi
@@ -7,10 +7,10 @@ function generateFunctionSignaturesInABI(
         .filter((abiEntry) => abiEntry.type === 'function')
         .forEach((abiEntry) => {
             const parameters = abiEntry.inputs.map((i) => i.type)
-            const signature = `${abiEntry.name}(${parameters.join(',')})`
-
-            const signatureHash = web3.utils.sha3(signature)
-            abiEntry.signature = signatureHash.substring(0, 10)
+            abiEntry.signature = createFunctionSignature({
+                functionName: abiEntry.name,
+                parameters
+            })
         })
 
     return abi

--- a/scripts/deploy/contracts/artifacts/loadArtifacts.js
+++ b/scripts/deploy/contracts/artifacts/loadArtifacts.js
@@ -1,0 +1,20 @@
+const loadArtifact = require('./loadArtifact')
+
+async function loadArtifacts({
+    contractNames,
+    networkName
+} = {}) {
+    const artifacts = []
+
+    for (const contractName of contractNames) {
+        const artifact = await loadArtifact(
+            contractName,
+            networkName
+        )
+        artifacts.push(artifact)
+    }
+
+    return artifacts
+}
+
+module.exports = loadArtifacts

--- a/scripts/deploy/contracts/evaluateContracts.js
+++ b/scripts/deploy/contracts/evaluateContracts.js
@@ -20,7 +20,7 @@ function evaluateContracts({
 
     if (verbose) {
         console.log(
-            `Deploying contracts: '${contracts.join(', ')}'`
+            `Contracts: '${contracts.join(', ')}'`
         )
     }
 

--- a/scripts/deploy/truffle-wrapper/auditWrapper.js
+++ b/scripts/deploy/truffle-wrapper/auditWrapper.js
@@ -1,0 +1,13 @@
+/* global web3 */
+const { argv } = require('yargs')
+const audit = require('../audit/audit')
+
+module.exports = (cb) => {
+    audit({
+        web3,
+        strict: false,
+        verbose: argv['verbose'] && true
+    })
+        .then(() => cb())
+        .catch(err => cb(err))
+}


### PR DESCRIPTION
## Description

Added audit functionality by running `npm run audit:[network]` will create logs like these: https://github.com/oceanprotocol/atlantic/commit/e3a14d5f8a6ed7a5b85742571ada45b99fe30b0d

Relates to: https://github.com/oceanprotocol/atlantic/pull/49