### PR TITLE
Timed out condition returns ConditionUpdated(_, Aborted, _, _) event

### DIFF
--- a/contracts/conditions/ConditionStoreLibrary.sol
+++ b/contracts/conditions/ConditionStoreLibrary.sol
@@ -48,7 +48,6 @@ library ConditionStoreLibrary {
         ConditionState _newState
     )
         internal
-        returns (ConditionState)
     {
         require(
             _self.conditions[_id].state == ConditionState.Unfulfilled &&
@@ -60,6 +59,5 @@ library ConditionStoreLibrary {
         _self.conditions[_id].lastUpdatedBy = msg.sender;
         _self.conditions[_id].blockNumberUpdated = block.number;
 
-        return _newState;
     }
 }

--- a/contracts/conditions/ConditionStoreManager.sol
+++ b/contracts/conditions/ConditionStoreManager.sol
@@ -183,17 +183,16 @@ contract ConditionStoreManager is Ownable, Common {
             updateState = ConditionStoreLibrary.ConditionState.Aborted;
         }
 
-        ConditionStoreLibrary.ConditionState state = conditionList
-            .updateState(_id, updateState);
+        conditionList.updateState(_id, updateState);
 
         emit ConditionUpdated(
             _id,
             conditionList.conditions[_id].typeRef,
-            _newState,
+            updateState,
             msg.sender
         );
 
-        return state;
+        return updateState;
     }
 
     function getConditionListSize()

--- a/test/unit/conditions/ConditionStoreManager.Test.js
+++ b/test/unit/conditions/ConditionStoreManager.Test.js
@@ -1085,7 +1085,7 @@ contract('ConditionStoreManager', (accounts) => {
                 constants.condition.state.aborted)
         })
 
-it('timed out condition should abort and emit corresponding ConditionUpdated event', async () => {
+        it('timed out condition should abort and emit corresponding ConditionUpdated event', async () => {
             const {
                 conditionStoreManager,
                 conditionId,
@@ -1096,13 +1096,13 @@ it('timed out condition should abort and emit corresponding ConditionUpdated eve
 
             const conditionTimeLock = 0
             const conditionTimeOut = 1
-    
+
             await conditionStoreManager.methods['createCondition(bytes32,address,uint256,uint256)'](
                 conditionId,
                 hashLockCondition.address,
-		conditionTimeLock,
-		conditionTimeOut,
-		{ from: createRole}
+                conditionTimeLock,
+                conditionTimeOut,
+                { from: createRole }
             )
 
             const newState = constants.condition.state.fulfilled
@@ -1114,7 +1114,7 @@ it('timed out condition should abort and emit corresponding ConditionUpdated eve
             )
 
             await increaseTime(1)
-    
+
             const result = await conditionStoreManager.updateConditionState(conditionId, newState)
 
             assert.strictEqual(
@@ -1127,8 +1127,7 @@ it('timed out condition should abort and emit corresponding ConditionUpdated eve
             expect(eventArgs._typeRef).to.equal(createRole)
             expect(eventArgs._state.toNumber()).to.equal(constants.condition.state.aborted)
         })
-	
-	
+
         it('timed out condition should not abort before timeout', async () => {
             const {
                 conditionStoreManager,

--- a/test/unit/libraries/sol/EpochLibraryTest.sol
+++ b/test/unit/libraries/sol/EpochLibraryTest.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.3;
+pragma solidity 0.5.6;
 
 import '../../../../contracts/libraries/EpochLibrary.sol';
 


### PR DESCRIPTION
## Description

- Calling `updateConditionState(_id, Fulfilled)` from `ConditionStoreManager` on a timed out condition now both updates the condition state to `Aborted` and returns the corresponding event `ConditionUpdated(_, Aborted, _, _)`
- Added the corresponding test to test/unit/conditions/ConditionStoreManager.Test.js under the "timeout conditions" category
- Removed the unnecessary return value from `updateState` in `ConditionStoreLibrary` and adjusted `updateConditionState` from `ConditionStoreManager` accordingly

closes #526 
